### PR TITLE
Add explicit README step for creating an admin

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ uv run python manage.py migrate
 
 ### 3. Create an admin user (optional)
 
-If you wish to try out the Django Admin dashboard or Wagtail dashboard,
+If you want to try out the Django Admin dashboard or Wagtail dashboard,
 create a superuser (admin) account which can be used for Django Admin and Wagtail:
 
 ```bash


### PR DESCRIPTION
Add an explicit step for creating an admin and include a note that the same admin account can access django admin and wagtail dashboards.